### PR TITLE
encode query params when doing people search

### DIFF
--- a/lib/people.js
+++ b/lib/people.js
@@ -54,13 +54,13 @@ people.prototype.get = function(options, callback) {
 };
 people.prototype.find = function(options, callback) {
 	var cb = callback || options;
-	var url = '/people/search.xml?';
+	var path = '/people/search.xml?';
 
 	var querystring = Object.keys(options).map(function(custom_field){
 		return encodeURIComponent("criteria[" + custom_field + "]=" + options[custom_field])
 	}).join('&')
 
-	url += querystring
+	var url = path + querystring
 
 	this.client.get_items(url, cb, require('./person'), 'people', 'person');
 };


### PR DESCRIPTION
Hey there, thanks for bootstrapping this project!

the query params need to be encoded, here is one way of doing it.  however you decide to do it, this will need to be done for all requests that have a query
