### PR TITLE
Required missing tag files

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -168,6 +168,8 @@ var highrise = function (config) {
 	this.tasks = new (require('./tasks'))(this.client);
 	this.user = new (require('./user'))(this.client);
 	this.users = new (require('./users'))(this.client);
+	this.tag = new (require('./tag'))(this.client);
+	this.tags = new (require('./tags'))(this.client);
 };
 
 module.exports = highrise;


### PR DESCRIPTION
tag.js and tags.js were never required by the client even though they were fully implemented  